### PR TITLE
feat(extensions): Allow hiding link connectors

### DIFF
--- a/web/extensions/core/linkRenderMode.js
+++ b/web/extensions/core/linkRenderMode.js
@@ -9,7 +9,7 @@ const ext = {
 			name: "Link Render Mode",
 			defaultValue: 2,
 			type: "combo",
-			options: LiteGraph.LINK_RENDER_MODES.map((m, i) => ({
+			options: [...LiteGraph.LINK_RENDER_MODES, "Hidden"].map((m, i) => ({
 				value: i,
 				text: m,
 				selected: i == app.canvas.links_render_mode,


### PR DESCRIPTION
Thank you for adding this feature (linksRenderMode) to core. I would like to add the "Hidden" option (invalid number 3 will just hide the connector lines), so that I can remove that extension from my extension pack to prevent conflicts

https://github.com/failfa-st/failfast-comfyui-extensions